### PR TITLE
Use source-path=SCRIPTDIR directive for relative file sourcing

### DIFF
--- a/lib/pulumi_test.sh
+++ b/lib/pulumi_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 oneTimeSetUp() {
-    # shellcheck source=lib/pulumi.sh
+    # shellcheck source-path=SCRIPTDIR
     source "$(dirname "${BASH_SOURCE[0]}")/pulumi.sh"
 }
 

--- a/lib/rc.sh
+++ b/lib/rc.sh
@@ -2,9 +2,9 @@
 
 set -euo pipefail
 
-# shellcheck source=lib/util.sh
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
-# shellcheck source=lib/pulumi.sh
+# shellcheck source-path=SCRIPTDIR
 source "$(dirname "${BASH_SOURCE[0]}")/pulumi.sh"
 
 # Given a project and stack name, and a flat JSON object as an input

--- a/lib/rc_test.sh
+++ b/lib/rc_test.sh
@@ -48,8 +48,7 @@ oneTimeSetUp() {
     export GIT_AUTHOR_NAME="Testy McTestface"
     export GIT_AUTHOR_EMAIL="tests@tests.com"
 
-    # This is the file we're actually testing
-    # shellcheck source=lib/rc.sh
+    # shellcheck source-path=SCRIPTDIR
     source "$(dirname "${BASH_SOURCE[0]}")/rc.sh"
 }
 

--- a/lib/record_test.sh
+++ b/lib/record_test.sh
@@ -13,7 +13,7 @@ recorded_commands() {
 
 oneTimeSetUp() {
     export ALL_COMMANDS="${SHUNIT_TMPDIR}/all_commands"
-    # shellcheck source=lib/record.sh
+    # shellcheck source-path=SCRIPTDIR
     source "$(dirname "${BASH_SOURCE[0]}")/record.sh"
 }
 

--- a/lib/util_test.sh
+++ b/lib/util_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 oneTimeSetUp() {
-    # shellcheck source=lib/util.sh
+    # shellcheck source-path=SCRIPTDIR
     source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 }
 

--- a/pants.toml
+++ b/pants.toml
@@ -45,3 +45,13 @@ args = ["-i 4", "-ci", "-sr"]
 
 [test]
 output = "all"
+
+[shellcheck]
+# Currently, Pants only knows about v0.7.1, but v0.7.2 has some nice
+# relative sourcing features we'd like to take advantage of (namely,
+# `script-path=SOURCEDIR`). Once Pants knows about v0.7.2 natively, we
+# can remove these configuration values.
+version = "v0.7.2"
+known_versions = [
+  "v0.7.2|linux|70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188|1382204"
+]


### PR DESCRIPTION
This is a bit more forgiving a way to handle file resolution, and
requires Shellcheck v0.7.2.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>