### PR TITLE
Replace leaf_paths with paths(scalars) for object flattening

### DIFF
--- a/lib/json_tools.sh
+++ b/lib/json_tools.sh
@@ -14,8 +14,8 @@ flatten_json() {
     local -r input_json="${1}"
     # https://stackoverflow.com/a/37557003
     jq -r '
-        . as $in 
-        | reduce leaf_paths as $path (
+        . as $in
+        | reduce paths(scalars) as $path (
             {};
             . + { ($path | map(tostring) | join(".")): $in | getpath($path) }
         )


### PR DESCRIPTION
According to the [documentation][1], `leaf_paths` is deprecated and
will be removed with the next major release of `jq`.

Instead, we should use `paths(scalars)`, for which `leaf_paths` is an
alias.

[1]: https://stedolan.github.io/jq/manual/#paths,paths(node_filter),leaf_paths

Signed-off-by: Christopher Maier <chris@graplsecurity.com>