### PR TITLE
Add Pulumi preview and update steps

### DIFF
--- a/steps/pulumi_preview.sh
+++ b/steps/pulumi_preview.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Run a `pulumi preview` on a given Pulumi stack.
+#
+# Assumptions:
+# - Python virtualenv is managed by Pants via `build-support/manage_virtualenv.sh`
+# - All Pulumi projects are stored in `pulumi/<project_name>`
+# - Projects are named in kebab-case, but directories for the projects
+#   are snake_case
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/pulumi.sh"
+
+# Given as "project/stack"
+readonly project_stack="${1}"
+
+echo -e "--- :python: Installing dependencies"
+build-support/manage_virtualenv.sh populate
+
+# shellcheck disable=SC1091
+source build-support/venv/bin/activate
+
+echo -e "--- :pulumi: Log in"
+pulumi login
+
+echo -e "--- :pulumi: Previewing changes to ${project_stack} infrastructure"
+pulumi preview \
+    --cwd="$(project_directory "${project_stack}")" \
+    --stack="$(fully_qualified_stack_name "${project_stack}")" \
+    --show-replacement-steps \
+    --non-interactive \
+    --diff \
+    --message="Previewing from ${BUILDKITE_BUILD_URL}"

--- a/steps/pulumi_up.sh
+++ b/steps/pulumi_up.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Run a `pulumi up` on a given Pulumi stack.
+#
+# Assumptions:
+# - Python virtualenv is managed by Pants via `build-support/manage_virtualenv.sh`
+# - All Pulumi projects are stored in `pulumi/<project_name>`
+# - Projects are named in kebab-case, but directories for the projects
+#   are snake_case
+
+set -euo pipefail
+
+# shellcheck source-path=SCRIPTDIR
+source "$(dirname "${BASH_SOURCE[0]}")/../lib/pulumi.sh"
+
+# Given as "project/stack"
+readonly project_stack="${1}"
+
+echo -e "--- :python: Installing dependencies"
+build-support/manage_virtualenv.sh populate
+
+# shellcheck disable=SC1091
+source build-support/venv/bin/activate
+
+echo -e "--- :pulumi: Log in"
+pulumi login
+
+echo -e "--- :pulumi: Update ${project_stack} infrastructure"
+pulumi up \
+    --cwd="$(project_directory "${project_stack}")" \
+    --stack="$(fully_qualified_stack_name "${project_stack}")" \
+    --show-replacement-steps \
+    --non-interactive \
+    --yes \
+    --diff \
+    --message="Updating from ${BUILDKITE_BUILD_URL}"


### PR DESCRIPTION
These are what we were using for our pipeline infrastructure project,
but extracted and modified to work within the common directory
structure (mainly changing `source` invocations).

This will enable us to use the same invocations in the Grapl
repository.

Signed-off-by: Christopher Maier <chris@graplsecurity.com>